### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.5"
+          go-version: 1.24.5
       - uses: helm/kind-action@v1
         with:
           cluster_name: kind


### PR DESCRIPTION
Potential fix for [https://github.com/corymurphy/argobot/security/code-scanning/1](https://github.com/corymurphy/argobot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily interacts with the repository's contents (e.g., checking out code and running tests). Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
